### PR TITLE
feat: implement public feed with posts from Supabase

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -2,17 +2,24 @@ import { render, screen } from '@/test/test-utils'
 import Home from './page'
 
 describe('Home Page', () => {
-  it('renders the home page with title', () => {
+  it('renders the home page structure', () => {
     render(<Home />)
 
     expect(screen.getByRole('heading', { name: 'EphemNotes' })).toBeInTheDocument()
     expect(screen.getByText('Share your ephemeral thoughts')).toBeInTheDocument()
+    expect(screen.getByText('Recent Posts')).toBeInTheDocument()
   })
 
-  it('shows recent posts section', () => {
+  it('renders navigation bar', () => {
     render(<Home />)
+    
+    expect(screen.getByRole('navigation')).toBeInTheDocument()
+  })
 
-    expect(screen.getByText('Recent Posts')).toBeInTheDocument()
-    expect(screen.getByText('No posts yet. Sign in to create your first post!')).toBeInTheDocument()
+  it('shows loading state initially', () => {
+    render(<Home />)
+    
+    const skeletons = screen.getAllByTestId('post-item-skeleton')
+    expect(skeletons.length).toBeGreaterThan(0)
   })
 })

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,15 +5,15 @@ import { getPosts } from '@/lib/posts'
 import { Suspense } from 'react'
 
 async function PostsList() {
-  let posts = []
-  let error = null
+  let posts: Awaited<ReturnType<typeof getPosts>> = []
+  let error: Error | null = null
 
   try {
     const supabase = await createServerSupabaseClient()
     posts = await getPosts(supabase)
   } catch (err) {
     console.error('Error fetching posts:', err)
-    error = err
+    error = err instanceof Error ? err : new Error('Failed to fetch posts')
   }
 
   return <PostFeed posts={posts} error={error} />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,23 @@
 import { NavBar } from '@/components/NavBar'
+import { PostFeed } from '@/components/PostFeed'
+import { createServerSupabaseClient } from '@/lib/supabase'
+import { getPosts } from '@/lib/posts'
+import { Suspense } from 'react'
+
+async function PostsList() {
+  let posts = []
+  let error = null
+
+  try {
+    const supabase = await createServerSupabaseClient()
+    posts = await getPosts(supabase)
+  } catch (err) {
+    console.error('Error fetching posts:', err)
+    error = err
+  }
+
+  return <PostFeed posts={posts} error={error} />
+}
 
 export default function Home() {
   return (
@@ -14,11 +33,9 @@ export default function Home() {
           <div className="mt-8">
             <h2 className="text-xl font-semibold mb-4">Recent Posts</h2>
             <div className="space-y-4">
-              <div className="p-4 border rounded-lg">
-                <p className="text-muted-foreground">
-                  No posts yet. Sign in to create your first post!
-                </p>
-              </div>
+              <Suspense fallback={<PostFeed isLoading />}>
+                <PostsList />
+              </Suspense>
             </div>
           </div>
         </main>

--- a/src/components/PostFeed.test.tsx
+++ b/src/components/PostFeed.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { PostFeed } from './PostFeed'
+import type { Post } from '@/lib/database.types'
+
+describe('PostFeed', () => {
+  const mockPosts: Post[] = [
+    {
+      id: '1',
+      user_id: 'user-1',
+      username: 'alice',
+      title: 'First Post',
+      body: 'Body 1',
+      published: true,
+      created_at: '2024-01-02T00:00:00Z',
+      updated_at: '2024-01-02T00:00:00Z',
+    },
+    {
+      id: '2',
+      user_id: 'user-2',
+      username: 'bob',
+      title: 'Second Post',
+      body: 'Body 2',
+      published: true,
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+    },
+  ]
+
+  it('displays loading skeletons when isLoading is true', () => {
+    render(<PostFeed isLoading />)
+    
+    const skeletons = screen.getAllByTestId('post-item-skeleton')
+    expect(skeletons).toHaveLength(3)
+  })
+
+  it('displays error state when error is provided', () => {
+    const error = new Error('Failed to fetch posts')
+    render(<PostFeed error={error} />)
+    
+    expect(screen.getByText('Error loading posts')).toBeInTheDocument()
+    expect(screen.getByText('Please try refreshing the page.')).toBeInTheDocument()
+  })
+
+  it('displays empty state when posts array is empty', () => {
+    render(<PostFeed posts={[]} />)
+    
+    expect(screen.getByText('No posts yet. Sign in to create your first post!')).toBeInTheDocument()
+  })
+
+  it('displays empty state when posts is null', () => {
+    render(<PostFeed posts={null} />)
+    
+    expect(screen.getByText('No posts yet. Sign in to create your first post!')).toBeInTheDocument()
+  })
+
+  it('displays posts when available', () => {
+    render(<PostFeed posts={mockPosts} />)
+    
+    expect(screen.getByText('alice wrote:')).toBeInTheDocument()
+    expect(screen.getByText('First Post')).toBeInTheDocument()
+    expect(screen.getByText('bob wrote:')).toBeInTheDocument()
+    expect(screen.getByText('Second Post')).toBeInTheDocument()
+  })
+
+  it('creates links to individual posts', () => {
+    render(<PostFeed posts={mockPosts} />)
+    
+    const links = screen.getAllByRole('link')
+    expect(links[0]).toHaveAttribute('href', '/posts/1')
+    expect(links[1]).toHaveAttribute('href', '/posts/2')
+  })
+
+  it('renders posts in the order provided', () => {
+    render(<PostFeed posts={mockPosts} />)
+    
+    const posts = screen.getAllByTestId('post-item')
+    expect(posts[0]).toHaveTextContent('alice wrote:')
+    expect(posts[0]).toHaveTextContent('First Post')
+    expect(posts[1]).toHaveTextContent('bob wrote:')
+    expect(posts[1]).toHaveTextContent('Second Post')
+  })
+})

--- a/src/components/PostFeed.test.tsx
+++ b/src/components/PostFeed.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { PostFeed } from './PostFeed'
-import type { Post } from '@/lib/database.types'
+import type { Post } from '@/lib/posts'
 
 describe('PostFeed', () => {
   const mockPosts: Post[] = [

--- a/src/components/PostFeed.tsx
+++ b/src/components/PostFeed.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { PostItem } from './PostItem'
-import type { Post } from '@/lib/database.types'
+import type { Post } from '@/lib/posts'
 
 interface PostFeedProps {
   posts?: Post[] | null

--- a/src/components/PostFeed.tsx
+++ b/src/components/PostFeed.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { PostItem } from './PostItem'
+import type { Post } from '@/lib/database.types'
+
+interface PostFeedProps {
+  posts?: Post[] | null
+  isLoading?: boolean
+  error?: Error | null
+}
+
+export function PostFeed({ posts, isLoading = false, error = null }: PostFeedProps) {
+  if (isLoading) {
+    return (
+      <>
+        <PostItem isLoading />
+        <PostItem isLoading />
+        <PostItem isLoading />
+      </>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="p-4 border rounded-lg border-destructive">
+        <p className="text-destructive font-semibold">Error loading posts</p>
+        <p className="text-sm text-muted-foreground mt-1">
+          Please try refreshing the page.
+        </p>
+      </div>
+    )
+  }
+
+  if (!posts || posts.length === 0) {
+    return (
+      <div className="p-4 border rounded-lg">
+        <p className="text-muted-foreground">
+          No posts yet. Sign in to create your first post!
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      {posts.map((post) => (
+        <PostItem 
+          key={post.id} 
+          post={post}
+          href={`/posts/${post.id}`}
+        />
+      ))}
+    </>
+  )
+}

--- a/src/components/PostItem.test.tsx
+++ b/src/components/PostItem.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { PostItem } from './PostItem'
+import type { Post } from '@/lib/database.types'
+
+describe('PostItem', () => {
+  const mockPost: Post = {
+    id: '1',
+    user_id: 'user-123',
+    username: 'testuser',
+    title: 'Test Post Title',
+    body: 'Test post body content',
+    published: true,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+  }
+
+  it('renders post with username and title in correct format', () => {
+    render(<PostItem post={mockPost} />)
+    
+    expect(screen.getByText('testuser wrote:')).toBeInTheDocument()
+    expect(screen.getByText('Test Post Title')).toBeInTheDocument()
+  })
+
+  it('renders loading skeleton when isLoading is true', () => {
+    render(<PostItem isLoading />)
+    
+    expect(screen.getByTestId('post-item-skeleton')).toBeInTheDocument()
+    expect(screen.queryByText('wrote:')).not.toBeInTheDocument()
+  })
+
+  it('handles post without username gracefully', () => {
+    const postWithoutUsername = { ...mockPost, username: null }
+    render(<PostItem post={postWithoutUsername} />)
+    
+    expect(screen.getByText('Anonymous wrote:')).toBeInTheDocument()
+    expect(screen.getByText('Test Post Title')).toBeInTheDocument()
+  })
+
+  it('handles post with empty title', () => {
+    const postWithEmptyTitle = { ...mockPost, title: '' }
+    render(<PostItem post={postWithEmptyTitle} />)
+    
+    expect(screen.getByText('testuser wrote:')).toBeInTheDocument()
+    expect(screen.getByText('(Untitled)')).toBeInTheDocument()
+  })
+
+  it('truncates very long titles', () => {
+    const longTitle = 'A'.repeat(150)
+    const postWithLongTitle = { ...mockPost, title: longTitle }
+    render(<PostItem post={postWithLongTitle} />)
+    
+    const titleElement = screen.getByTestId('post-title')
+    expect(titleElement).toHaveClass('truncate')
+  })
+
+  it('applies correct styling for post item', () => {
+    render(<PostItem post={mockPost} />)
+    
+    const container = screen.getByTestId('post-item')
+    expect(container).toHaveClass('p-4')
+    expect(container).toHaveClass('border')
+    expect(container).toHaveClass('rounded-lg')
+  })
+
+  it('renders multiple loading skeletons with different animation delays', () => {
+    const { container } = render(
+      <>
+        <PostItem isLoading />
+        <PostItem isLoading />
+        <PostItem isLoading />
+      </>
+    )
+    
+    const skeletons = container.querySelectorAll('[data-testid="post-item-skeleton"]')
+    expect(skeletons).toHaveLength(3)
+  })
+
+  it('handles post with all null/undefined fields', () => {
+    const emptyPost: Partial<Post> = {
+      id: '1',
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+    }
+    render(<PostItem post={emptyPost as Post} />)
+    
+    expect(screen.getByText('Anonymous wrote:')).toBeInTheDocument()
+    expect(screen.getByText('(Untitled)')).toBeInTheDocument()
+  })
+
+  it('makes post clickable when href is provided', () => {
+    render(<PostItem post={mockPost} href="/posts/1" />)
+    
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', '/posts/1')
+  })
+
+  it('renders as div when no href is provided', () => {
+    render(<PostItem post={mockPost} />)
+    
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    expect(screen.getByTestId('post-item').tagName).toBe('DIV')
+  })
+})

--- a/src/components/PostItem.test.tsx
+++ b/src/components/PostItem.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { PostItem } from './PostItem'
-import type { Post } from '@/lib/database.types'
+import type { Post } from '@/lib/posts'
 
 describe('PostItem', () => {
   const mockPost: Post = {

--- a/src/components/PostItem.tsx
+++ b/src/components/PostItem.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import Link from 'next/link'
+import type { Post } from '@/lib/database.types'
+
+interface PostItemProps {
+  post?: Post
+  isLoading?: boolean
+  href?: string
+}
+
+export function PostItem({ post, isLoading = false, href }: PostItemProps) {
+  if (isLoading) {
+    return (
+      <div 
+        data-testid="post-item-skeleton"
+        className="p-4 border rounded-lg animate-pulse"
+      >
+        <div className="flex items-baseline gap-2">
+          <div className="h-4 w-24 bg-muted rounded" />
+          <div className="h-4 w-12 bg-muted rounded" />
+          <div className="h-5 w-48 bg-muted rounded" />
+        </div>
+      </div>
+    )
+  }
+
+  const username = post?.username || 'Anonymous'
+  const title = post?.title || '(Untitled)'
+
+  const content = (
+    <div 
+      data-testid="post-item"
+      className="p-4 border rounded-lg hover:bg-muted/50 transition-colors"
+    >
+      <div className="flex items-baseline gap-2">
+        <span className="text-sm text-muted-foreground">{username} wrote:</span>
+        <span data-testid="post-title" className="font-semibold truncate">
+          {title}
+        </span>
+      </div>
+    </div>
+  )
+
+  if (href) {
+    return (
+      <Link href={href} className="block">
+        {content}
+      </Link>
+    )
+  }
+
+  return content
+}

--- a/src/components/PostItem.tsx
+++ b/src/components/PostItem.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import type { Post } from '@/lib/database.types'
+import type { Post } from '@/lib/posts'
 
 interface PostItemProps {
   post?: Post

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,8 +1,37 @@
-import { createBrowserClient } from '@supabase/ssr'
+import { createBrowserClient, createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+import type { Database } from './database.types'
 
 export function createClient() {
-  return createBrowserClient(
+  return createBrowserClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  )
+}
+
+export async function createServerSupabaseClient() {
+  const cookieStore = await cookies()
+
+  return createServerClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll()
+        },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) => {
+              cookieStore.set(name, value, options)
+            })
+          } catch {
+            // The `set` method was called from a Server Component.
+            // This can be ignored if you have middleware refreshing
+            // user sessions.
+          }
+        },
+      },
+    }
   )
 }


### PR DESCRIPTION
## Summary
- Implemented a public feed that displays posts from Supabase
- Created PostItem and PostFeed components with loading and error states
- Posts are fetched server-side and ordered by creation date (newest first)

## Changes
- **PostItem Component**: Displays individual posts in "username wrote: Title" format with loading skeleton support
- **PostFeed Component**: Handles the display of multiple posts with loading, error, and empty states
- **Home Page Update**: Integrated server-side data fetching from Supabase to display posts
- **Server Supabase Client**: Added secure server-side client for fetching data
- **Comprehensive Tests**: Added tests for all new components with good coverage

## Test Plan
- [x] Unit tests for PostItem component
- [x] Unit tests for PostFeed component
- [x] Integration tests for home page
- [x] ESLint passes without errors
- [ ] Manual testing of feed functionality
- [ ] Verify posts display correctly when data exists in Supabase
- [ ] Verify error handling when Supabase is unavailable

Closes #6

🤖 Generated with [Claude Code](https://claude.ai/code)